### PR TITLE
refac/ Allow `nomencl` package usage

### DIFF
--- a/politex.cls
+++ b/politex.cls
@@ -251,27 +251,22 @@
 %% Numbering schemes
 \ifthenelse{\equal{\ABNTpnum}{ABNT}}{
 	% ABNT strict
-	% Page style is empty until TOC
-	\renewcommand{\thepage}{}
-	
-	\renewcommand{\ABNTBeginOfTextualPart}{
-		\renewcommand{\thepage}{\arabic{page}}
-		\pagestyle{POLIheader}
-		\renewcommand{\chaptertitlepagestyle}{POLIheader}
-	}
+  % Page style is empty until TOC
+	% We leave this statement intentionally blank 
 }{
 	% Roman/Arabic
 	% Use roman numerals for pretextual part
 	% Use arabic numerals for textual part (restart counter)
 	\renewcommand{\thepage}{\roman{page}}
-	
-	\renewcommand{\ABNTBeginOfTextualPart}{
-		\setcounter{page}{1}
-		\renewcommand{\thepage}{\arabic{page}}
-		\pagestyle{POLIheader}
-		\renewcommand{\chaptertitlepagestyle}{POLIheader}
-	}
 }
+
+\renewcommand{\ABNTBeginOfTextualPart}{
+    \setcounter{page}{1}
+    \renewcommand{\thepage}{\arabic{page}}
+    \pagestyle{POLIheader}
+    \renewcommand{\chaptertitlepagestyle}{POLIheader}
+}
+
 
 
 %%%%%%  LINE SPACING  %%%%%%


### PR DESCRIPTION
Allow nomenclature usage by removal of command \renewcommand{\thepage}{}